### PR TITLE
RAI-16129 - Task created in Raycast are hardcoded to use "WORK" as the eventCategory

### DIFF
--- a/extensions/reclaim-ai/CHANGELOG.md
+++ b/extensions/reclaim-ai/CHANGELOG.md
@@ -1,5 +1,8 @@
 # reclaim Changelog
 
+## [Fixes] - 2024-10-25
+- Don't hardcode task category to "work"
+
 ## [Update] - 2024-10-16
 - Add Sentry support
 

--- a/extensions/reclaim-ai/src/hooks/useTask.tsx
+++ b/extensions/reclaim-ai/src/hooks/useTask.tsx
@@ -25,7 +25,7 @@ export const useTaskActions = () => {
 
   const createTask = async (task: CreateTaskProps) => {
     const data = {
-      eventCategory: "WORK",
+      eventCategory: task.category,
       timeSchemeId: task.timePolicy,
       title: task.title,
       timeChunksRequired: task.timeNeeded,


### PR DESCRIPTION
## Description

Task category was hardcoded as "WORK" and now respects Personal selection
## Screencast


## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used by the `README` are placed outside of the `metadata` folder
