### PR TITLE
Scott/rai 18954 raycast update packagejson to mention outlook google

### DIFF
--- a/extensions/reclaim-ai/CHANGELOG.md
+++ b/extensions/reclaim-ai/CHANGELOG.md
@@ -1,5 +1,8 @@
 # reclaim Changelog
 
+## [Update] - 2024-06-03
+- Update to the package.json description to include Outlook as a valid calendar provider.
+
 ## [Fixes] - 2025-04-02
 - Don't split surrogate pairs
 

--- a/extensions/reclaim-ai/package.json
+++ b/extensions/reclaim-ai/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "reclaim-ai",
   "title": "Reclaim",
-  "description": "AI scheduling for Google Calendar – quickly create Tasks, join meetings, share Scheduling Links, & manage your calendar",
+  "description": "AI scheduling for Google & Outlook Calendar – quickly create Tasks, join meetings, share Scheduling Links, & manage your calendar.",
   "icon": "command-icon.png",
   "author": "lightbody",
   "contributors": [


### PR DESCRIPTION
## Description

Update to the package.json description to include Outlook as a valid calendar provider.

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
